### PR TITLE
fix typo

### DIFF
--- a/es6/2013-03/mar-12.md
+++ b/es6/2013-03/mar-12.md
@@ -89,7 +89,7 @@ MM: ES has a grammatical specification for validating and parsing JSON. Anything
 
 DC: Or we don't change the spec
 
-MM: The way that you properly reject our favorite fixes, I thinkk you should apply to your favorite fixes
+MM: The way that you properly reject our favorite fixes, I think you should apply to your favorite fixes
 
 DC: I'll consider that
 


### PR DESCRIPTION
There was a typo in `mar-12.md`.
