### PR TITLE
Fix `<module>` tag not being in back-ticks

### DIFF
--- a/es6/2013-11/nov-21.md
+++ b/es6/2013-11/nov-21.md
@@ -108,7 +108,7 @@ YK: can you show me what's secure today that does blacklisting?
 AR: no, but that's not the argument.
 
 
-<module> is a better 1JS
+`<module>` is a better 1JS
 
 - Better global scoping: starts in a nested scope
 - To Create persistent globals, must opt in, by mutating window/this


### PR DESCRIPTION
Without it being in back-ticks, markdown things it looks like an HTML tag
