### PR TITLE
Add a missing double quote in Modules Feedback

### DIFF
--- a/es6/2014-04/apr-10.md
+++ b/es6/2014-04/apr-10.md
@@ -118,7 +118,7 @@ var Foo = require("foo");
 var Foo = require("foo").Foo;
 
 // The latter is the same as:
-var f = require("foo);
+var f = require("foo");
 var Foo = f.Foo;
 ```
 


### PR DESCRIPTION
Hi, a little fixes.
Added `"` in 4.10 Modules Feedback
