### PR TITLE
Add a missing backtick in Decorators for ES7

### DIFF
--- a/es6/2014-04/apr-10.md
+++ b/es6/2014-04/apr-10.md
@@ -549,7 +549,7 @@ class Person extends Ember.Object {
     // ...deal with the change
   }
 }
-
+```
 
 YK: Goals:
 


### PR DESCRIPTION
A little markdown syntax fixes.
