### PR TITLE
Fix codeblock formatting

### DIFF
--- a/es6/2014-09/sept-24.md
+++ b/es6/2014-09/sept-24.md
@@ -113,7 +113,13 @@ Slide 10
 Works in both class constructors and function constructors 
                                                 
 ```js
-SubArray.__proto__ = Array;  SubArray.prototype = Object.create([].prototype);   function SubArray(...args) {    if (!this^) this = new SubArray(...args);    else this = new super(...args);  }  
+SubArray.__proto__=Array;
+SubArray.prototype=Object.create([].prototype);
+func,on SubArray(...args) {
+	if (!this^) this = new SubArray(...args);
+	else this = new super(...args);
+} 
+```
 
 MM: You can do assignment to `this` when called as a function?
 


### PR DESCRIPTION
@rwaldron Hi, This patch contains following fixes.

- Add missing backtick ```
- Copy code from pdf and paste it! :)

![2014-10-29_15-50-53](https://cloud.githubusercontent.com/assets/19714/4821962/7735199e-5f38-11e4-811d-eddd15f2e5fd.jpg)
