### PR TITLE
Fix some typo in 2015-07

### DIFF
--- a/es7/2015-07/july-28.md
+++ b/es7/2015-07/july-28.md
@@ -145,7 +145,6 @@ WH: But much longer since 5.1
 AWB: 
   
 - Errata?
-- 
 
 
 Discussion re: schedule, responsibilities, etc. 

--- a/es7/2015-07/july-28.md
+++ b/es7/2015-07/july-28.md
@@ -148,7 +148,7 @@ AWB:
 - 
 
 
-Discusson re: schedule, responsibilities, etc. 
+Discussion re: schedule, responsibilities, etc. 
 
 AWB: We will submit to ISO, with exact same text (subject to ISO naming, etc). But the text will include any known errors. 
 
@@ -169,7 +169,7 @@ WH: Not a lot of work
 
 DD: You're saying that you no longer agree to fast track
 
-WH: We will get ocmments from ISO reviewers, these will identify defects, these need to be fixed. It is our job to fix
+WH: We will get comments from ISO reviewers, these will identify defects, these need to be fixed. It is our job to fix
 
 CM: Exactly the proposal: take the existing text and put it in the pipeline and publish the errata later. 
 
@@ -364,10 +364,10 @@ AWB: Used as argument to the RegExp constructor
 
 DD: yes
 
-Safe Wth Extra Escape Set
+Safe With Extra Escape Set
 
 - Escapes everything the SyntaxCharacter proposal does
-- Escapes `-` addl. for the context sentive inside-character-class matching
+- Escapes `-` addl. for the context sensitive inside-character-class matching
 - Escapes hex numeric literals (0-9a-f) at the start of the string in order to 
 - Less readable output but safer
 

--- a/es7/2015-07/july-29.md
+++ b/es7/2015-07/july-29.md
@@ -363,7 +363,7 @@ With Sam's proposa, this would return `[undefined, Global]`, despite expecting `
   "use strict";
   return [this, foo];
 })();
-
+```
 
 DH: In ES5, there was a fundamental confusion about "use strict" in functions. This was excacerbated by es6. In the fullness of time, TC39 is saying, the directive prologue should be used:
 

--- a/es7/2015-07/july-29.md
+++ b/es7/2015-07/july-29.md
@@ -165,7 +165,7 @@ BE: Suggestion fixes the right-to-left violation
 DH: Could enumerate all those cases and make errors, but much harder. 
 - Fixes, but means new rule
 
-YK: Poisioning `function () { "use strict" }`
+YK: Poisoning `function () { "use strict" }`
 
 BE: use top level "use strict"
 

--- a/es7/2015-07/july-29.md
+++ b/es7/2015-07/july-29.md
@@ -846,7 +846,6 @@ WH: Note that I'm not alone with that argument. I don't want this to become pers
 
 - `new` throws
 - not separate spec
-- 
 - spec mechansisms: Allen, Brian, Rick and Dan to work through
 - Reviewers:
     - Waldemar Horwat

--- a/es7/2015-07/july-29.md
+++ b/es7/2015-07/july-29.md
@@ -365,7 +365,7 @@ With Sam's proposa, this would return `[undefined, Global]`, despite expecting `
 })();
 ```
 
-DH: In ES5, there was a fundamental confusion about "use strict" in functions. This was excacerbated by es6. In the fullness of time, TC39 is saying, the directive prologue should be used:
+DH: In ES5, there was a fundamental confusion about "use strict" in functions. This was exacerbated by ES6. In the fullness of time, TC39 is saying, the directive prologue should be used:
 
 - Global "use strict" (being careful of script concatenation)
 - Top-level IIFE "use strict"

--- a/es7/2015-07/july-30.md
+++ b/es7/2015-07/july-30.md
@@ -307,7 +307,6 @@ BT: want to be very clear about rationalization, so that same can be applied to 
 
 AWB: The generator function returns its value before evaluating its body. 
 - A generator is a function
-- 
 
 MM: An async generator... I missed the rest of this
 
@@ -854,7 +853,6 @@ MM: further semantics need to be explored
 - Approved for Stage 2
 - Reviewers
   - Andreas Rossberg
-  - 
 
 
 


### PR DESCRIPTION
This pull request fixes some typo and markdown syntax.

----

@rwaldron Thank you for your work! 
 I'm always looking forward to seeing meeting note :memo: :)