### PR TITLE
Fix some typo in 2016-11

### DIFF
--- a/es7/2016-11/dec-1.md
+++ b/es7/2016-11/dec-1.md
@@ -340,7 +340,7 @@ MM: if integration reveals issues for one and not the other? THen we can address
 
 AWB: Or drop entirely?
 
-YK/AWB/DE: (dscussion of the merging concerns, but only w/ regard to Stage 3?)
+YK/AWB/DE: (discussion of the merging concerns, but only w/ regard to Stage 3?)
 
 AWB: Concerns about separate proposals modifying the same spec algorithms. They need to be merged when we get to that level of detail.
 

--- a/es7/2016-11/dec-1.md
+++ b/es7/2016-11/dec-1.md
@@ -564,7 +564,7 @@ AWB: We use IdentifierName in the grammar
 WH: It seems odd to have a PrivateName be a single token. The more natural way to express it would be as two tokens, `#` followed by an IdentifierName.
 
 KG: Won't that allow whitespace between `#` and IdentifierName?
-- The hash is intended to be thought of as part of the proeprty name, ie: 
+- The hash is intended to be thought of as part of the property name, ie: 
     
 ```js
 this.

--- a/es7/2016-11/nov-29.md
+++ b/es7/2016-11/nov-29.md
@@ -191,7 +191,7 @@ BT: other languages have it. It's easy for Chakra to implement. Spec changes are
 
 JHD: This could start off a chain of calls to .then. To run the code on the same tick and return a Promise, so it's different from Promise.resolve().then().
 
-_DIscussion about what the semantics of the job loop are_
+_Discussion about what the semantics of the job loop are_
 
 JHD: This avoids creating an immediately invoked async function, avoids the Promise constructor, etc.
 
@@ -384,6 +384,9 @@ BT: We should either come to consensus that we don't want Promise subclassing, a
 (Daniel Ehrenberg)
 
 DE: _shows the PR_
+
+- [Issue](https://github.com/tc39/ecma262/issues/713)
+- [PR](https://github.com/tc39/ecma262/pull/724)
 
 DE: For TypedArrays we want to be consistent, same for `length`  checks.
 

--- a/es7/2016-11/nov-29.md
+++ b/es7/2016-11/nov-29.md
@@ -418,7 +418,7 @@ DE: Possible...
 - Consensus on taking the PR (aka throwing on detached typed array during iteration via ValidateTypedArray)
 - consensus example [found here](https://github.com/tc39/ecma262/issues/713#issuecomment-255878360) (the first option, "a")
 
-```js
+```
 8. If a has a [[TypedArrayName]] internal slot, then
   a. Perform ? ValidateTypedArray(a).
   b. Let len be a.[[ArrayLength]].

--- a/es7/2016-11/nov-29.md
+++ b/es7/2016-11/nov-29.md
@@ -125,11 +125,14 @@ DE: OK, so if I do this some time over the next two months will that be in time?
 AWB: ye
 
 DE: PRs to get into ES2018:
-    - https://github.com/tc39/ecma402/pull/84
-    - https://github.com/tc39/ecma402/pull/114
+
+- https://github.com/tc39/ecma402/pull/84
+- https://github.com/tc39/ecma402/pull/114
+
 Possible proposals at Stage 3 which may reach Stage 4 by January and be integrated:
-    - https://github.com/tc39/ecma402/issues/30
-    - https://github.com/tc39/proposal-intl-plural-rules
+
+- https://github.com/tc39/ecma402/issues/30
+- https://github.com/tc39/proposal-intl-plural-rules
 
 ## 9 ECMA404 and ECMA414 Updates
 
@@ -618,9 +621,9 @@ DH: If there's a lookahead restriction on expressions...
 
 DD, WH: There's no lookahead involved here; this is just what grammars do, and by the time you get to the reduce part of the grammar you know which form you have
 
-    - Parens are usually required anyway, e.g., if you'll then the result
-    - If we were to do `await import x`, then it would be impossible because we've already used the unary operator
-    - Another possibility (though AWB expressed dislike) is local import being hoisted, which this would disallow
+- Parens are usually required anyway, e.g., if you'll then the result
+- If we were to do `await import x`, then it would be impossible because we've already used the unary operator
+- Another possibility (though AWB expressed dislike) is local import being hoisted, which this would disallow
     
 AWB: Pros for unary operator, with a low precedence like yield:
     - We are looking at something which is not a call, it's really based on conceptual state

--- a/es7/2016-11/nov-29.md
+++ b/es7/2016-11/nov-29.md
@@ -613,8 +613,9 @@ KG: Would it be an actual function?
 
 DD: No, needs to be a function-like form.
 Pros for function-like:
-    - Future extensibility (second argument)
-    - Ambiguity with 'import x' form in modules. You could use this from a script, and you might expect that you can write 'import x' in a script. But that would not be the same--it would create a Promise and then throw it away
+
+- Future extensibility (second argument)
+- Ambiguity with 'import x' form in modules. You could use this from a script, and you might expect that you can write 'import x' in a script. But that would not be the same--it would create a Promise and then throw it away
     
 AWB: You could require it to be parenthesized when it's in statement position, with the same logic that prohibits a function expression there
 

--- a/es7/2016-11/nov-30.md
+++ b/es7/2016-11/nov-30.md
@@ -36,7 +36,7 @@ AWB: No desire to continue long-term, even if funding issues were resolved. I've
 
 YK: Thanks to DE for improvements to meeting process, has assisted chair.
 
-YK: FInding a good chair is not an emergency, in case we end up with a bad chair.
+YK: Finding a good chair is not an emergency, in case we end up with a bad chair.
 
 AWB: We need a collective sense of urgency here.
 IS: What is also important that TC39 members think about what kind of chair / vice chair (that position is also open...) they would like to see for the next period. In the past 6 years we had a chair who was not an ECMAScript expert, so really neutral, but with the current new requirements maybe a chair with some strategic guidance would be good. This is really something TC39 should think about and decide.

--- a/es7/2016-11/nov-30.md
+++ b/es7/2016-11/nov-30.md
@@ -842,8 +842,8 @@ DE: Don't know the entire history?
 
 Terminology: 
     
-    - scramble: replace a nan with another arbitrary nan
-    - canonicalize: replace a nan with a _particular_ nan value. 
+- scramble: replace a nan with another arbitrary nan
+- canonicalize: replace a nan with a _particular_ nan value. 
 
 DE: V8 may violate the ES standard for NaN observable behavior, but I want to argue that it’s OK
 

--- a/es7/2016-11/nov-30.md
+++ b/es7/2016-11/nov-30.md
@@ -769,7 +769,7 @@ Room: yes.
 
 (Daniel Ehrenberg)
 
-- [proposa](https://github.com/tc39/proposal-intl-segmenter)
+- [proposal](https://github.com/tc39/proposal-intl-segmenter)
 
 DE: Motivation: https://github.com/tc39/proposal-intl-segmenter#motivation
 


### PR DESCRIPTION
Fix some typo and formatting markdown.

/cc @rwaldron 