### PR TITLE
new set builtin methods to stage 1

### DIFF
--- a/es8/2018-01/summary.md
+++ b/es8/2018-01/summary.md
@@ -21,6 +21,7 @@
 - [Top-level await](jan-24.md#13iiil-top-level-await-for-stage-0) to Stage 1
 - [Maximally minimal mixins proposal](jan-23.md#13iiie-maximally-minimal-mixins-proposal) to [Stage 1](jan-24.md#revisiting-mixins-vs-protocols-proposal).
 - [Getting last item from Array](jan-24.md#13iiim-getting-last-item-from-array-for-stage-2) to Stage 1 with plans for further work.
+- [new Set builtin methods](jan-23.md#13iiik-new-set-builtin-methods-for-stage-2) to be split into two proposals and both advance to stage1
 
 ### Moving Forward
 
@@ -45,7 +46,6 @@ _Proposals not advancing to new a new stage. e.g.: development updates, needs wo
 
 - [Function.prototype.toString](jan-23.md#13iiic-functionprototypetostring-pr-for-stage-4) still on Stage 3 with plans for a follow up work.
 - [Making nullish values iterable, or at least array-spreadable](jan-23.md#13iiif-pr-making-nullish-values-iterable-or-at-least-array-spreadable) discussion to follow up on the respective [PR](https://github.com/tc39/ecma262/pull/1069).
-- [new Set builtin methods](jan-23.md#13iiik-new-set-builtin-methods-for-stage-2) for further discussion before advancing to Stage 2.
 - [Optional Chaining updates](jan-24.md#13iiin-optional-chaining-update).
 - Discussion on [operator overloading](jan-24.md#13vd-operator-overloading-for-stage-1), not advancing to Stage 1 for now to collect requirements.
 - [TC39 should endorse use of a (one-of-several, not one specific recommended) parsing linter or actual compiler, not any particular semicolon style](jan-24.md#15iiia-tc39-should-endorse-use-of-a-one-of-several-not-one-specific-recommended-parsing-linter-or-actual-compiler-not-any-particular-semicolon-style).


### PR DESCRIPTION
From the [meeting notes
](https://github.com/rwaldron/tc39-notes/blob/master/es8/2018-01/jan-23.md#13iiik-new-set-builtin-methods-for-stage-2)

```
Conclusion/Resolution
Stage 1 for Set-specific methods
Stage 1 for the more generic methods Array-like methods (for both Set and Map)
```