### PR TITLE
fix some typo in 2018-01

### DIFF
--- a/es8/2018-01/jan-23.md
+++ b/es8/2018-01/jan-23.md
@@ -877,7 +877,6 @@ JHD: any objections to moving this to stage 3?
 (Michael Ficarra)
 
  - [proposal](https://github.com/tc39/Function-prototype-toString-revision)
- - [slides]()
 
 MF: has been sitting in stage 3 for a while, spec text hasn't changed for a year. Now have multiple implementations..
 

--- a/es8/2018-01/jan-23.md
+++ b/es8/2018-01/jan-23.md
@@ -665,7 +665,7 @@ SM: one use case, one source of non-determinism in their ? is to hard-code a see
 
 - [Issue](https://github.com/tc39/Reflector/issues/104)
 - [old form](http://tc39.github.io/test262-cla/)
-- [new form](https://littledan.github.io/agreements/contributor/)
+- [new form](https://tc39.github.io/agreements/contributor/)
 
 DE: Since 2015 we've been using GitHub for development, accepting contributions on GitHub. Have occasional non-members attending meetings. We need confirmation that contributions can be legal (patent/IPR). We ask them to sign a web form. There are technical issues with this form. To fix those, we made a second form, with different text about the agreements/licensing, for non-members to sign when making contributions. Thomas Wood of Imperial College London has promised to help with automating.
 

--- a/es8/2018-01/jan-23.md
+++ b/es8/2018-01/jan-23.md
@@ -1248,7 +1248,7 @@ DD: should this censor the function name itself? What about a meta-API with a we
 
 DD: pragma variant is opt-in by author of the library, external version is opt-in by host or by user of the library. Pragma doesn't break existing code. Lots of ways to modify behavior of code included inthe app that don't edit your source text, this would add another one, apps are already making choices about whether to depend upon such things.
 
-DD: requires only mimimal preprocessing
+DD: requires only minimal preprocessing
 
 DD: precedent for out-of-band controls :CSP disallows eval(), proposed realms API is controlled externally, Node.js enables/disables i18n features with flags
 

--- a/es8/2018-01/jan-24.md
+++ b/es8/2018-01/jan-24.md
@@ -542,7 +542,7 @@ YK: isn't that an objection for all variants?
 
 DD: your D seem very exotic
 
-MBS: use cases: dynamic dependency pathing: `const strings = await import(`/i18n/${navigator.language}`);`
+MBS: use cases: dynamic dependency pathing: ``const strings = await import(`/i18n/${navigator.language}`);``
 
 MBS: resource initialization: `const connection = await dbConnector();` Lets modules represent resources and produce errors, instead of putting all of your code inside the on()
 

--- a/es8/2018-01/jan-24.md
+++ b/es8/2018-01/jan-24.md
@@ -64,7 +64,7 @@ JHD: We have tests, editor-reviewed spec PR. Asking for Stage 4. Any objections?
 (Gabriel Isenberg)
 
  - [proposal](https://github.com/tc39/proposal-optional-chaining)
- - [slides]()
+
 
 GI: proposing: obj??.prop obj??[expr] func??(...args) and some day someValue ??: defaultValue
 
@@ -439,7 +439,7 @@ ZB: any objections to stage 3?
 (Ron Buckton)
 
  - [proposal](https://github.com/tc39/proposal-throw-expressions)
- - [slides]()
+
 
 RBN: for the past couple of meetings we've been discussing throw expressions, relatively small change to the spec, but pretty interesting, moving some statements over to expression forms. Allow the use of "throw" in an expression context. For required parameters, arrow function bodies, conditionals, logical, nullish coalesce
 
@@ -921,7 +921,6 @@ DE: we can iterate on the wording on github
 
 (Diego Ferreiro Val, Yehuda Katz and Carido Patino)
 
-- [slides]()
 
 YK: purpose is to share use cases, not to propose anything for advancement
 

--- a/es8/2018-01/jan-24.md
+++ b/es8/2018-01/jan-24.md
@@ -64,7 +64,7 @@ JHD: We have tests, editor-reviewed spec PR. Asking for Stage 4. Any objections?
 (Gabriel Isenberg)
 
  - [proposal](https://github.com/tc39/proposal-optional-chaining)
-
+ - [slides](https://docs.google.com/presentation/d/1tAxG8y-lfMty2-qdiCAtQjD9rS8xzBe9Y4b_ti9DIMQ/edit?usp=sharing)
 
 GI: proposing: obj??.prop obj??[expr] func??(...args) and some day someValue ??: defaultValue
 
@@ -921,6 +921,7 @@ DE: we can iterate on the wording on github
 
 (Diego Ferreiro Val, Yehuda Katz and Carido Patino)
 
+ - [slides](https://docs.google.com/presentation/d/178WoBNhXBBB1M_LlSqnKEic4SD4CFYtO9Fkr9rvsHaA/view)
 
 YK: purpose is to share use cases, not to propose anything for advancement
 

--- a/es8/2018-01/jan-25.md
+++ b/es8/2018-01/jan-25.md
@@ -46,7 +46,7 @@ ZB: Intl.Locale is a building block for any i18n. Previously all APIs accepted a
 
 ZB: allows for language negotiation, allows people to implement their own formaters, avoids need for people to do pseudo-parsing of the language tag strings
 
-ZB: at stage 2, had some recommended changes. Accept well-formed language tags even if we don't recognize that language. Internal changes to rely on Intl.Locale in contsructors, can pass one into date/time constructors. Compared to BCP47 we do one more operation: deduplicate, sort. BCP47 does not standardize that, so that's our extension.
+ZB: at stage 2, had some recommended changes. Accept well-formed language tags even if we don't recognize that language. Internal changes to rely on Intl.Locale in constructors, can pass one into date/time constructors. Compared to BCP47 we do one more operation: deduplicate, sort. BCP47 does not standardize that, so that's our extension.
 
 ZB: propose to advance to stage 3. Questions?
 

--- a/es8/2018-01/jan-25.md
+++ b/es8/2018-01/jan-25.md
@@ -44,7 +44,7 @@ BT: has been implemented a number of times, in chrome, safari, firefox, babel, t
 
 ZB: Intl.Locale is a building block for any i18n. Previously all APIs accepted a (string) BCP47? language tag. now we ..?
 
-ZB: allows for language negotiation, allows people to implement their own formaters, avoids need for people to do pseudo-parsing of the language tag strings
+ZB: allows for language negotiation, allows people to implement their own formatters, avoids need for people to do pseudo-parsing of the language tag strings
 
 ZB: at stage 2, had some recommended changes. Accept well-formed language tags even if we don't recognize that language. Internal changes to rely on Intl.Locale in constructors, can pass one into date/time constructors. Compared to BCP47 we do one more operation: deduplicate, sort. BCP47 does not standardize that, so that's our extension.
 

--- a/es8/2018-01/jan-25.md
+++ b/es8/2018-01/jan-25.md
@@ -639,7 +639,7 @@ AWB: I think changing `set` (doing lossy casts when appropriate) is consistent w
 
 Jakob: for existing typed arrays, you can assign a string, if it contains a number, it converts the string to a number, then takes the bits from the number that it needs depending upon how wide the array is. For the ? proposal I'm not sure it does any more.
 
-Jakob: this is an exmpla of the type conversion that arrays have always done. these new typedarrays are doing it differently. I'm fine with doing it differently, just wanted to point out the inconsistently
+Jakob: this is an example of the type conversion that arrays have always done. these new typedarrays are doing it differently. I'm fine with doing it differently, just wanted to point out the inconsistently
 
 AWB: general job of value conversion.. I can see an argument that TypedArrays themselves are kind of special in how they map between different numeric element types, and in that context, bigints .. would be a reasonable expectations
 

--- a/es8/2018-01/jan-25.md
+++ b/es8/2018-01/jan-25.md
@@ -637,7 +637,7 @@ DE: right, (example on screen from issue), PR changes the semantics of `set`.. s
 
 AWB: I think changing `set` (doing lossy casts when appropriate) is consistent with history of TypedArray
 
-Jakob: for existing typed arrays, you can assign a string, if it contains a number, it converts the stirng to a number, then takes the bits from the number that it needs depending upon how wide the array is. For the ? proposal I'm not sure it does any more.
+Jakob: for existing typed arrays, you can assign a string, if it contains a number, it converts the string to a number, then takes the bits from the number that it needs depending upon how wide the array is. For the ? proposal I'm not sure it does any more.
 
 Jakob: this is an exmpla of the type conversion that arrays have always done. these new typedarrays are doing it differently. I'm fine with doing it differently, just wanted to point out the inconsistently
 


### PR DESCRIPTION
This PR fix some typo.
And I remove empty slices link like `[slides]()`.